### PR TITLE
kill BLK_MQ_F_SG_MERGE macro

### DIFF
--- a/main.c
+++ b/main.c
@@ -307,7 +307,7 @@ static int sblkdev_add_device(void)
             dev->tag_set.queue_depth = 128;
             dev->tag_set.numa_node = NUMA_NO_NODE;
             dev->tag_set.cmd_size = sizeof(sblkdev_cmd_t);
-            dev->tag_set.flags = BLK_MQ_F_SHOULD_MERGE | BLK_MQ_F_SG_MERGE;
+            dev->tag_set.flags = BLK_MQ_F_SHOULD_MERGE ;
             dev->tag_set.driver_data = dev;
 
             ret = blk_mq_alloc_tag_set(&dev->tag_set);


### PR DESCRIPTION
https://lore.kernel.org/patchwork/patch/1042759/

BLK_MQ_F_SG_MERGE macro has been killed in v5 kernels, so remove these macros according to the patch.